### PR TITLE
POC: TCA + SwiftData Query

### DIFF
--- a/SwiftDataTCA.xcodeproj/project.pbxproj
+++ b/SwiftDataTCA.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		23A64EA72ACF5812005B6344 /* MovieDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A64EA62ACF5812005B6344 /* MovieDatabase.swift */; };
 		23A64EA92ACF5855005B6344 /* Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A64EA82ACF5855005B6344 /* Database.swift */; };
 		23A64EAD2AD1AB46005B6344 /* MovieMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A64EAC2AD1AB46005B6344 /* MovieMigration.swift */; };
+		80180C422AFBECC900ADAB03 /* QueryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80180C412AFBECC900ADAB03 /* QueryView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -28,6 +29,7 @@
 		23A64EA62ACF5812005B6344 /* MovieDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDatabase.swift; sourceTree = "<group>"; };
 		23A64EA82ACF5855005B6344 /* Database.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Database.swift; sourceTree = "<group>"; };
 		23A64EAC2AD1AB46005B6344 /* MovieMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieMigration.swift; sourceTree = "<group>"; };
+		80180C412AFBECC900ADAB03 /* QueryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,6 +96,7 @@
 			children = (
 				23A64EAB2AD1AB36005B6344 /* Migrations */,
 				23A64E9E2ACC5E16005B6344 /* ContentView.swift */,
+				80180C412AFBECC900ADAB03 /* QueryView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -183,6 +186,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				23A64EA72ACF5812005B6344 /* MovieDatabase.swift in Sources */,
+				80180C422AFBECC900ADAB03 /* QueryView.swift in Sources */,
 				23A64E9F2ACC5E16005B6344 /* ContentView.swift in Sources */,
 				23A64EAD2AD1AB46005B6344 /* MovieMigration.swift in Sources */,
 				23A64EA92ACF5855005B6344 /* Database.swift in Sources */,

--- a/SwiftDataTCA/SwiftDataTCAApp.swift
+++ b/SwiftDataTCA/SwiftDataTCAApp.swift
@@ -7,15 +7,38 @@
 
 import SwiftUI
 import SwiftData
+import Dependencies
 
 @main
 struct SwiftDataTCAApp: App {
+    @Dependency(\.databaseService) var databaseService
+    var modelContext: ModelContext {
+        guard let modelContext = try? self.databaseService.context() else {
+            fatalError("Could not find modelcontext")
+        }
+        return modelContext
+    }
+    
     var body: some Scene {
         WindowGroup {
-            TCAContentView(store: .init(initialState: TCAContentView.Feature.State(), reducer: {
-                TCAContentView.Feature()
-                    ._printChanges()
-            }))
+            TabView {
+                TCAContentView(store: .init(initialState: TCAContentView.Feature.State(), reducer: {
+                    TCAContentView.Feature()
+                        ._printChanges()
+                }))
+                .tabItem {
+                    Label("TCAContentView", systemImage: "1.circle")
+                }
+                
+                QueryView(store: .init(initialState: .init(), reducer: {
+                    QueryReducer()._printChanges()
+                }))
+                .modelContext(self.modelContext)
+                .tabItem {
+                    Label("QueryView", systemImage: "2.circle")
+                }
+            }
+            
         }
     }
 }

--- a/SwiftDataTCA/View/QueryView.swift
+++ b/SwiftDataTCA/View/QueryView.swift
@@ -1,0 +1,102 @@
+//
+//  QueryView.swift
+//  SwiftDataTCA
+//
+//  Created by Daniel Lyons on 11/8/23.
+//
+
+import Foundation
+import SwiftUI
+import ComposableArchitecture
+import SwiftData
+import Dependencies
+
+struct QueryView: View {
+    let store: StoreOf<QueryReducer>
+    
+    
+    @Query(FetchDescriptor<Movie>()) var moviesQuery: [Movie] {
+        didSet {
+            store.send(.queryChangedMovies(self.allMovies))
+        }
+    }
+    
+    var body: some View {
+        WithViewStore(store, observe: { $0 }) { viewStore in
+            NavigationStack {
+                List {
+                    ForEach(self.moviesQuery) { movie in
+                        VStack {
+                            Text("\(movie.title)").font(.title)
+                            Text("\(movie.id)")
+                        }
+                        .background(movie.favorite ? .blue : .clear)
+                        .swipeActions {
+                            Button("Delete", systemImage: "trash", role: .destructive) {
+                                viewStore.send(.delete(movie), animation: .snappy)
+                            }
+                            Button("Toggle Favorite", systemImage: "star") {
+                                viewStore.send(.favorite(movie), animation: .snappy)
+                            }
+                        }
+                    }
+                }
+                .navigationTitle("Movies Query")
+                .toolbar {
+                    Button("Add sample", systemImage: "plus") {
+                        viewStore.send(.addMovie, animation: .snappy)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct QueryReducer: Reducer {
+    struct State: Equatable {
+        var movies: [Movie] = []
+    }
+    
+    enum Action: Equatable {
+        case queryChangedMovies([Movie])
+        case addMovie
+        case delete(Movie)
+        case favorite(Movie)
+    }
+    
+    @Dependency(\.swiftData) var context
+    @Dependency(\.databaseService) var databaseService
+    
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+                case .queryChangedMovies(let newMovies):
+                    state.movies = newMovies
+                    return .none
+                case .addMovie:
+                    do {
+                        let randomMovieName = ["Star Wars", "Harry Potter", "Hunger Games", "Lord of the Rings"].randomElement()!
+                        try context.add(.init(title: randomMovieName, cast: ["Sam Worthington", "Zoe Saldaña", "Stephen Lang", "Michelle Rodriguez"]))
+                    } catch { }
+                    return .none
+                case .delete(let movieToDelete):
+                    do {
+                        try context.delete(movieToDelete)
+                    } catch { }
+                    return .none
+                case .favorite(let movieToFavorite):
+                    movieToFavorite.favorite.toggle()
+                    guard let context = try? self.databaseService.context() else {
+                        print("Failed to find context")
+                        return .none
+                    }
+                    do {
+                        try context.save()
+                    } catch {
+                        print("Failed to save")
+                    }
+                    return .none
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a proof of concept of another way to implement SwiftData in TCA. 

In `QueryView`, TCA never actually handles fetching. Instead, the `@Query` property wrapper handles all fetching, and every time it's changed, then it's `didSet` will call `store.send(.queryChangedMovies(self.allMovies))`. 

## ADVANTAGES
- We no longer have to update our data manually as `@Query` will handle this on our behalf. 
- SwiftData and TCA should stay in sync as every time `@Query` changes, it must update TCA. 
- `@Query` should be able to update our data even when side effects happen outside TCA (e.g. sync updates from CloudKit). 

## Limitations
- Currently, `@Query` does not allow you to dynamically change your `FetchDescriptor` during it's lifetime. This is a limitation that Core Data also used to have in SwiftUI. However, SwiftUI later added that feature, and I would be surprised if SwiftData does not ship the same/similar feature next year. 
    - In the meanwhile, there is a workaround: A parent view, with a parent reducer can construct a new Query any time a searchString, `#Predicate`, or `SortDescriptor` is changed. When any of these changes, it creates a new child View with the same state except for with an updated `Query`. A non-TCA implementation of that technique can be found [here](https://www.hackingwithswift.com/quick-start/swiftdata/filtering-the-results-from-a-swiftdata-query). 