### PR TITLE
use .onChange to observe moviesQuery instead

### DIFF
--- a/SwiftDataTCA/View/QueryView.swift
+++ b/SwiftDataTCA/View/QueryView.swift
@@ -14,18 +14,13 @@ import Dependencies
 struct QueryView: View {
     let store: StoreOf<QueryReducer>
     
-    
-    @Query(FetchDescriptor<Movie>()) var moviesQuery: [Movie] {
-        didSet {
-            store.send(.queryChangedMovies(self.allMovies))
-        }
-    }
+    @Query(FetchDescriptor<Movie>()) var moviesQuery: [Movie]
     
     var body: some View {
-        WithViewStore(store, observe: { $0 }) { viewStore in
+        WithViewStore(store, observe: \.movies) { viewStore in
             NavigationStack {
                 List {
-                    ForEach(self.moviesQuery) { movie in
+                    ForEach(viewStore.state) { movie in
                         VStack {
                             Text("\(movie.title)").font(.title)
                             Text("\(movie.id)")
@@ -46,6 +41,9 @@ struct QueryView: View {
                     Button("Add sample", systemImage: "plus") {
                         viewStore.send(.addMovie, animation: .snappy)
                     }
+                }
+                .onChange(of: self.moviesQuery, initial: true) { _, newValue in
+                    viewStore.send(.queryChangedMovies(newValue))
                 }
             }
         }


### PR DESCRIPTION
inside `
@Query(FetchDescriptor<Movie>()) var moviesQuery: [Movie] {
        didSet {
            store.send(.queryChangedMovies(self.allMovies))
        }
    }
` the 'didSet' is actually never executed. 

And the original code happened to work because `ForEach(self.moviesQuery)`, which seems should be replaced by `ForEach(viewStore.state)` to make it more TCA-like.